### PR TITLE
Make the instructions more precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Ferryboot is a customizable bootloader development project. This project is desi
 
 2. **Clone the Project**:
    ```bash
-   git clone <repository-url>
-   cd Ferryboot
+   git clone https://github.com/melihxz/ferryboot
+   cd ferryboot
    ```
 
 3. **Build the Project**:


### PR DESCRIPTION
Changed <repository-url> to the real URL and Ferryboot to ferryboot. This way, people can easily copy and paste the instructions to clone the repository :)